### PR TITLE
Added base GCP code implementations

### DIFF
--- a/migrations/8__add_google_cloud_provider.sql
+++ b/migrations/8__add_google_cloud_provider.sql
@@ -1,0 +1,2 @@
+INSERT INTO providers (id, display_name, required_variables, supports_spot) VALUES 
+    ('gcp', 'Google Cloud Platform', 'GOOGLE_APPLICATION_CREDENTIALS', 1);

--- a/src/integrations/providers/gcp/interface.rs
+++ b/src/integrations/providers/gcp/interface.rs
@@ -1,0 +1,20 @@
+use crate::database::models::{ConfigVar, ConfigVarFinder};
+
+use anyhow::{Result, bail};
+use reqwest::{Client as HttpClient, header};
+use serde_json::Value as JsonValue;
+use tracing::error;
+
+pub struct GcpInterface {
+    pub config_vars: Vec<ConfigVar>,
+}
+
+/// TODO: Decide over using the Rust SDK or the REST API...
+/// Rust SDK: https://github.com/googleapis/google-cloud-rust/tree/main
+/// REST API: https://cloud.google.com/compute/docs/authentication?hl=pt-br#rest
+///
+/// If using the API, check the Vultr code for an example on how to use the `reqwest` http
+/// client for requests.
+/// If using the Rust SDK, check the SDK own documentation and the AWS code to get an idea of
+/// how to implement this method.
+impl GcpInterface {}

--- a/src/integrations/providers/gcp/mod.rs
+++ b/src/integrations/providers/gcp/mod.rs
@@ -1,0 +1,5 @@
+mod interface;
+mod resource_catalog;
+mod resource_manager;
+
+pub use interface::GcpInterface;

--- a/src/integrations/providers/gcp/resource_catalog.rs
+++ b/src/integrations/providers/gcp/resource_catalog.rs
@@ -1,0 +1,39 @@
+use crate::database::models::{InstanceType, MachineImage};
+use crate::integrations::CloudInfoProvider;
+use crate::utils::ProgressTracker;
+
+use anyhow::{Result, bail};
+use std::collections::HashMap;
+
+use super::interface::GcpInterface;
+
+impl CloudInfoProvider for GcpInterface {
+    async fn fetch_regions(&self, _tracker: &ProgressTracker) -> Result<Vec<String>> {
+        bail!("Not implemented")
+    }
+
+    async fn fetch_zones(&self, _region: &str, _tracker: &ProgressTracker) -> Result<Vec<String>> {
+        bail!("Not implemented")
+    }
+
+    async fn fetch_instance_types(
+        &self,
+        _region: &str,
+        _tracker: &ProgressTracker,
+    ) -> Result<Vec<InstanceType>> {
+        bail!("Not implemented")
+    }
+
+    async fn fetch_prices(
+        &self,
+        _region: &str,
+        _instance_types: &[String],
+        _tracker: &ProgressTracker,
+    ) -> Result<HashMap<String, f64>> {
+        bail!("Not implemented")
+    }
+
+    async fn fetch_machine_image(&self, _region: &str, _image_id: &str) -> Result<MachineImage> {
+        bail!("Not implemented")
+    }
+}

--- a/src/integrations/providers/gcp/resource_manager.rs
+++ b/src/integrations/providers/gcp/resource_manager.rs
@@ -1,0 +1,36 @@
+use crate::database::models::{Cluster, Node};
+use crate::integrations::CloudResourceManager;
+
+use anyhow::{Result, bail};
+use sqlx::sqlite::SqlitePool;
+
+use super::interface::GcpInterface;
+
+impl CloudResourceManager for GcpInterface {
+    async fn spawn_cluster(
+        &self,
+        _pool: &SqlitePool,
+        _cluster: Cluster,
+        _nodes: Vec<Node>,
+    ) -> Result<()> {
+        bail!("Not implemented")
+    }
+
+    async fn terminate_cluster(
+        &self,
+        _pool: &SqlitePool,
+        _cluster: Cluster,
+        _nodes: Vec<Node>,
+    ) -> Result<()> {
+        bail!("Not implemented")
+    }
+
+    async fn simulate_cluster_failure(
+        &self,
+        _pool: &SqlitePool,
+        _cluster: Cluster,
+        _node_private_ip: &str,
+    ) -> Result<()> {
+        bail!("Not implemented")
+    }
+}

--- a/src/integrations/providers/mod.rs
+++ b/src/integrations/providers/mod.rs
@@ -1,2 +1,3 @@
 pub mod aws;
+pub mod gcp;
 pub mod vultr;


### PR DESCRIPTION
# Google Cloud Platform Support

## 1. Authentication
Currently, our database migration sets GOOGLE_APPLICATION_CREDENTIALS as the required variable, which expects a JSON file path. However, this approach has limitations:

Requires users to have the gcloud CLI tool installed to generate the credentials file
Creates a dependency on external tooling that we'd prefer to avoid

We need to determine the minimal authentication requirements for Google Cloud API access. Research if GOOGLE_APPLICATION_CREDENTIALS can accept the JSON content directly (as a string) instead of a file path, and investigate alternative authentication methods that don't require gcloud CLI. If needed, break down the service account JSON into individual variables (e.g., private_key, client_email, project_id, etc.) to allow manual input. Update the database migration with the final authentication variable requirements.

## 2. API Client Implementation Strategy
The official [Google Cloud Rust SDK](https://github.com/googleapis/google-cloud-rust/tree/main) just reached version 1.0.0 (released 3 days ago), but concerns exist:
  
  1. Documentation is sparse and potentially incomplete
  2. Uncertain coverage of all required Google Cloud services
  3. May be too early for production use given its recent release

Audit the Rust SDK to verify it includes all services we need (Compute Engine, IAM, etc.) and evaluate the quality and completeness of the SDK documentation. Compare SDK implementation complexity vs. direct [Google Cloud REST API](https://cloud.google.com/compute/docs/authentication?hl=pt-br#rest) calls.

If going through the REST API route, check the Vultr implementations for examples on how to use the `reqwest` package to build and make the HTTP requests. The interface for Google Cloud needs to be implemented in `src/integrations/providers/gcp/interface.rs`

## 3. Core Functionality Implementation
Implement the essential provider methods for full Google Cloud Platform support (contained in the following files):

Resource Catalog: `src/integrations/providers/gcp/resource_catalog.rs`
Resource Manager: `src/integrations/providers/gcp/resource_manager.rs`